### PR TITLE
Serve demo app with hot reload on dev server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ npm run watch
 
 ### Run the demo app
 
+#### Using a dev server
+
+For local development, with hot reload:
+```
+npm run serve
+```
+This runs the app at `http://localhost:8080` and loads it in your Web browser.
+
+
+#### Using a Web server
+
 Host the `/dist` directory on a Web server - either public or localhost.
 
 If the `CHANNEL_PREFIX` hasn't been configured, it is recommended that you host the app at one of the following paths:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "install-audio-api": "npm install hifi-web-audio@latest --registry https://npm.highfidelity.com/ --no-save",
         "install-local-audio-api": "npm install file:../hifi-web-audio-api --no-save",
         "build": "rimraf ./dist && webpack --mode production",
-        "watch": "rimraf ./dist && webpack --mode development --watch --progress"
+        "watch": "rimraf ./dist && webpack --mode development --watch --progress",
+        "serve": "rimraf ./dist && webpack serve --open --mode development"
     },
     "dependencies": {
         "@daily-co/daily-js": "^0.36.1",
@@ -23,6 +24,7 @@
         "rimraf": "^4.4.0",
         "ts-loader": "^9.4.2",
         "webpack": "^5.75.0",
-        "webpack-cli": "^5.0.1"
+        "webpack-cli": "^5.0.1",
+        "webpack-dev-server": "^4.13.1"
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,14 @@ module.exports = (env, argv) => {
         output: {
             filename: 'audio-room.js',
             path: path.resolve(__dirname, 'dist')
+        },
+        devServer: {
+            static: {
+                directory: './dist'
+            },
+            devMiddleware: {
+                writeToDisk: true
+            },
         }
     };
 


### PR DESCRIPTION
Adds the following command that builds and serves the app on a local Webpack dev server with hot reload:
```
npm run serve
```
This builds the app and loads it in your browser at http://localhost:8080. Whenever a change is made to HTML or code the app is automatically rebuilt and reloaded.