### PR TITLE
Fix resize observer running on after leaving video room.

### DIFF
--- a/example/audio-room.js
+++ b/example/audio-room.js
@@ -246,8 +246,8 @@ function fastLog2(x) {
 //
 // Sortable layout of video elements
 //
-let sortable;
-let resizeObserver;
+let sortable = null;
+let resizeObserver = null;
 
 
 function readyVideoSortable() {
@@ -262,6 +262,16 @@ function readyVideoSortable() {
     });
     resizeObserver = new ResizeObserver(updateVideoPositions);
     resizeObserver.observe(playerlist); // update positions on resize
+}
+
+function clearVideoSortable() {
+    if (!sortable) {
+        return;
+    }
+
+    sortable = null;
+    resizeObserver.disconnect();
+    resizeObserver = null;
 }
 
 
@@ -701,7 +711,9 @@ async function joinRoom() {
         sendUsername();
         return;
     }
+
     joined = true;
+    clearVideoSortable();
     updateRoomsUI();
 
     options.token = $("#token").val();
@@ -776,9 +788,6 @@ async function joinRoom() {
         // Play the local video track
         hiFiAudio.playVideo(listenerUid, "local-player");
     } else {
-        sortable = null;
-        resizeObserver = null;
-
         //
         // canvas GUI
         //


### PR DESCRIPTION
Fixes the following runtime error encountered if you visit the video room then switch to another room:

![image](https://user-images.githubusercontent.com/7455448/228709086-40499971-1503-409e-a731-8d4d6c2df03d.png)

Without this fix, the resizeObserver used by the video room executes after leaving the video room before joining the next.