### PR TITLE
Display "cannot join" if room requires metadata and browser not capable.

### DIFF
--- a/example/audio-room.js
+++ b/example/audio-room.js
@@ -707,6 +707,11 @@ async function fetchToken(uid /*: string */, channelName /*: string */, tokenRol
 
 
 async function joinRoom() {
+    if (roomOptions[currentRoomID].metaData && !HiFiAudio.isMetadataSupported()) {
+        displayCannotJoinRoomUI();
+        return;
+    }
+
     if (joined) {
         updateAudioControlsUI();
         updateRoomsUI();
@@ -870,6 +875,30 @@ function updateAudioControlsUI() {
 }
 
 
+function displayCannotJoinRoomUI() {
+    for (const rID of roomIDs) {
+        let roomButton = document.getElementById(rID);
+        let roomButtonCircle = document.getElementById(rID + "-circle");
+        if (rID === currentRoomID) {
+            roomButton.style.background = "#007bff";
+            roomButtonCircle.style.fill = "#7fbfff";
+        } else {
+            roomButton.style.background = "#D9E8EF";
+            roomButtonCircle.style.fill = "";
+        }
+    }
+
+    const canvasContainer = document.getElementById("canvas-container");
+    const videoroomContainer = document.getElementById("playerlist");
+    const noMetadataContainer = document.getElementById("no-metadata");
+    canvasContainer.style.display = "none";
+    videoroomContainer.style.display = "none";
+    noMetadataContainer.style.display = "block";
+
+    $("#leave").attr("disabled", true);
+    $("#join").attr("disabled", false);
+}
+
 function updateRoomsUI() {
     for (const rID of roomIDs) {
         let roomButton = document.getElementById(rID);
@@ -888,6 +917,7 @@ function updateRoomsUI() {
 
         let canvasContainer = document.getElementById("canvas-container");
         let videoroomContainer = document.getElementById("playerlist");
+        let noMetadataContainer = document.getElementById("no-metadata");
         if (ropts.video) {
             canvasContainer.style.display = "none";
             videoroomContainer.style.display = "block";
@@ -895,6 +925,7 @@ function updateRoomsUI() {
             canvasContainer.style.display = "block";
             videoroomContainer.style.display = "none";
         }
+        noMetadataContainer.style.display = "none";
 
         let localSoundSwitchLabel = document.getElementById("local-source-switch-label");
         let localSoundSwitchP = document.getElementById("local-source-switch-p");

--- a/example/index.css
+++ b/example/index.css
@@ -318,6 +318,24 @@ input[type=range] {
     transition: box-shadow 0.2s ease-in-out;
 }
 
+.no-metadata {
+    height: min-content;
+    min-height: 500px;
+    position: relative;
+    background: #DAD9D9;
+}
+
+.no-metadata p {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 80%;
+    text-align: center;
+    line-height: 1.5;
+    color: #000;
+}
+
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
     input[type=range] {
         overflow: hidden;

--- a/example/index.html
+++ b/example/index.html
@@ -164,6 +164,10 @@
           </div>
         </div>
 
+        <div id="no-metadata" class="no-metadata">
+            <p>Cannot join room because browser does not support audio stream metadata.</p>
+        </div>
+
         <div id="continue-dialog" class="continue-dialog">
           <button disabled id="continue" type="submit" class="btn btn-primary btn-sm">Continue...</button>
         </div>


### PR DESCRIPTION
In Firefox, a message is displayed if you try to join the Conference, Music, or Bar room:
![image](https://user-images.githubusercontent.com/7455448/235281742-3a3163a5-a618-45ef-9b4b-fe239f587d03.png)

The Video room still works in Firefox, though.